### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,56 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo builds
+        uses: swatinem/rust-cache@v2
+
+      - name: Install cargo-binstall
+        run: cargo install cargo-binstall --locked
+
+      - name: Install dioxus-cli
+        run: cargo binstall dioxus-cli --force
+
+      - name: Check project
+        run: dx check
+
+      - name: Bundle for web
+        run: dx bundle --platform web
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add GitHub Pages workflow that builds the Dioxus project on pushes to main
- install dioxus-cli with cargo-binstall and cache Rust builds for faster runs
- bundle the web output and publish the dist/ folder via GitHub Pages actions

## Testing
- Not run (workflow configuration only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922fe42653883288acd8b84a639d2cb)